### PR TITLE
Use card grid layout on start menu

### DIFF
--- a/start.php
+++ b/start.php
@@ -15,48 +15,30 @@ $rolle     = $_SESSION["rolle"];
 <head>
     <meta charset="UTF-8">
     <title>Startmenü</title>
-    <style>
-        body {
-            font-family: sans-serif;
-            background-color: #f7f7f7;
-            margin: 50px;
-            text-align: center;
-        }
-        .container {
-            max-width: 600px;
-            margin: auto;
-            background: white;
-            padding: 30px;
-            border-radius: 10px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-        }
-        h1 {
-            margin-bottom: 20px;
-        }
-        .button {
-            display: block;
-            width: 100%;
-            padding: 15px;
-            margin: 10px 0;
-            background-color: #007BFF;
-            color: white;
-            text-decoration: none;
-            border-radius: 5px;
-            font-size: 18px;
-        }
-        .button:hover {
-            background-color: #0056b3;
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container">
     <h1>Willkommen <?= htmlspecialchars($kuerzel) ?> (<?= htmlspecialchars($rolle) ?> – <?= htmlspecialchars($abteilung) ?>)</h1>
 
-    <a class="button" href="lernen.php">📘 Lernen</a>
-    <a class="button" href="suchen.php">🔍 Suchen</a>
-    <a class="button" href="bearbeiten.php">✏️ Bearbeiten</a>
-    <a class="button" href="hinzufuegen.php">➕ Wissen hinzufügen</a>
+    <div class="card-grid">
+        <a class="card card-learn" href="lernen.php">
+            <div class="icon">📘</div>
+            <div>Lernen</div>
+        </a>
+        <a class="card card-search" href="suchen.php">
+            <div class="icon">🔍</div>
+            <div>Suchen</div>
+        </a>
+        <a class="card card-edit" href="bearbeiten.php">
+            <div class="icon">✏️</div>
+            <div>Bearbeiten</div>
+        </a>
+        <a class="card card-add" href="hinzufuegen.php">
+            <div class="icon">➕</div>
+            <div>Wissen hinzufügen</div>
+        </a>
+    </div>
 
     <p><a href="logout.php">Abmelden</a></p>
 </div>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,71 @@
+body {
+    font-family: sans-serif;
+    background-color: #f7f7f7;
+    margin: 50px;
+    text-align: center;
+}
+
+.container {
+    max-width: 600px;
+    margin: auto;
+    background: white;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+    margin-bottom: 20px;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 20px;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    background-color: var(--bg, #fff);
+    color: var(--color, #000);
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+}
+
+.icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.card-learn {
+    --bg: #e3f2fd;
+    --color: #0d47a1;
+}
+
+.card-search {
+    --bg: #f3e5f5;
+    --color: #4a148c;
+}
+
+.card-edit {
+    --bg: #e8f5e9;
+    --color: #1b5e20;
+}
+
+.card-add {
+    --bg: #fff3e0;
+    --color: #e65100;
+}
+


### PR DESCRIPTION
## Summary
- Replace start page buttons with card grid linking to each section
- Add responsive CSS grid layout with coloured cards and hover effects

## Testing
- `php -l start.php`


------
https://chatgpt.com/codex/tasks/task_e_689e92703e40832bab34a2cf01a8784d